### PR TITLE
feat: サムネイル自動生成モジュール（issue #3）

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 obsws-python>=1.8.0
 PyYAML>=6.0
+Pillow>=9.0.0

--- a/src/thumbnail.py
+++ b/src/thumbnail.py
@@ -1,0 +1,256 @@
+"""サムネイル自動生成モジュール
+
+礼拝情報（日付・タイトル・聖書箇所・説教者）をテンプレート画像に
+テキスト合成して YouTube 推奨サイズ（1280×720px）の PNG を生成する。
+"""
+
+import logging
+import warnings
+from pathlib import Path
+from typing import Optional
+
+from PIL import Image, ImageDraw, ImageFont
+
+logger = logging.getLogger(__name__)
+
+# デフォルト設定値
+_DEFAULT_TEMPLATE_PATH = "assets/thumbnail_template.png"
+_DEFAULT_FONT_PATH = "C:/Windows/Fonts/meiryob.ttc"
+_OUTPUT_SIZE = (1280, 720)
+_OUTPUT_FILENAME = "thumbnail.png"
+
+_DEFAULTS: dict = {
+    "template_path": _DEFAULT_TEMPLATE_PATH,
+    "font_path": _DEFAULT_FONT_PATH,
+    "date": {"x": 80, "y": 40, "size": 48, "color": [255, 255, 255], "max_width": 600},
+    "title": {"x": 80, "y": 160, "size": 64, "color": [255, 255, 255], "max_width": 1100},
+    "scripture": {"x": 80, "y": 400, "size": 40, "color": [220, 220, 220], "max_width": 900},
+    "preacher": {"x": 80, "y": 480, "size": 40, "color": [220, 220, 220], "max_width": 600},
+}
+
+
+def generate_thumbnail(
+    date: str,
+    title: str,
+    scripture: str,
+    preacher: str,
+    output_dir: Path,
+    config: Optional[dict] = None,
+) -> Path:
+    """礼拝情報からサムネイル画像を生成し、output_dir に thumbnail.png として保存する。
+
+    Parameters
+    ----------
+    date : str
+        礼拝日の文字列。例: "2026年4月19日"
+    title : str
+        説教タイトル。例: "忘れ得じ、彼のパリサイびと"
+    scripture : str
+        聖書箇所。例: "ヨハネの福音書 3章1〜15節"
+    preacher : str
+        説教者名。例: "前田 重雄 師"
+    output_dir : Path
+        サムネイル PNG を保存するディレクトリ。存在しない場合は FileNotFoundError を送出する。
+    config : dict | None
+        config.yaml の thumbnail セクション（辞書）。None の場合はデフォルト設定で動作する。
+
+    Returns
+    -------
+    Path
+        生成した thumbnail.png の絶対パス。
+
+    Raises
+    ------
+    FileNotFoundError
+        テンプレート画像が存在しない場合、または output_dir が存在しない場合。
+    OSError
+        フォントファイルの読み込みに失敗し、フォールバックも失敗した場合。
+    """
+    cfg = config or {}
+
+    # output_dir の存在確認
+    output_dir = Path(output_dir)
+    if not output_dir.exists():
+        raise FileNotFoundError(f"output_dir が存在しません: {output_dir}")
+
+    # テンプレートパスの解決
+    template_path_str = cfg.get("template_path", _DEFAULTS["template_path"])
+    template_path = Path(template_path_str)
+    if not template_path.is_absolute():
+        # リポジトリルート（src の親）からの相対パスとして解決する
+        repo_root = Path(__file__).parent.parent
+        template_path = repo_root / template_path
+    if not template_path.exists():
+        raise FileNotFoundError(f"テンプレート画像が存在しません: {template_path}")
+
+    # テンプレート画像の読み込み
+    img = Image.open(template_path).convert("RGB")
+
+    # サイズが 1280×720 でない場合はリサイズ
+    if img.size != _OUTPUT_SIZE:
+        logger.warning(
+            "テンプレート画像のサイズが %s です。%s にリサイズします。",
+            img.size,
+            _OUTPUT_SIZE,
+        )
+        img = img.resize(_OUTPUT_SIZE, Image.LANCZOS)
+
+    draw = ImageDraw.Draw(img)
+
+    # フォントパスの取得
+    font_path = cfg.get("font_path", _DEFAULTS["font_path"])
+
+    # 各フィールドの描画
+    fields = [
+        ("date", date),
+        ("title", title),
+        ("scripture", scripture),
+        ("preacher", preacher),
+    ]
+
+    for field_name, text in fields:
+        field_defaults = _DEFAULTS[field_name]
+        field_cfg = cfg.get(field_name, {})
+
+        x = field_cfg.get("x", field_defaults["x"])
+        y = field_cfg.get("y", field_defaults["y"])
+        size = field_cfg.get("size", field_defaults["size"])
+        color = field_cfg.get("color", field_defaults["color"])
+        max_width = field_cfg.get("max_width", field_defaults["max_width"])
+
+        font = load_font(font_path, size, fallback=True)
+        fill = tuple(color)
+
+        if not text:
+            logger.warning("フィールド '%s' が空文字列です。", field_name)
+
+        draw_text_wrapped(
+            draw=draw,
+            text=text,
+            position=(x, y),
+            font=font,
+            fill=fill,
+            max_width=max_width,
+        )
+
+    # PNG として保存
+    output_path = output_dir / _OUTPUT_FILENAME
+    img.save(output_path, format="PNG")
+    logger.info("サムネイルを保存しました: %s", output_path)
+
+    return output_path.resolve()
+
+
+def load_font(
+    font_path: str,
+    size: int,
+    fallback: bool = True,
+) -> ImageFont.FreeTypeFont:
+    """指定パスのフォントを読み込む。
+
+    Parameters
+    ----------
+    font_path : str
+        フォントファイルの絶対パス。
+    size : int
+        フォントサイズ（ピクセル）。
+    fallback : bool
+        True の場合、フォントファイルが存在しなければ ImageFont.load_default() を返す。
+        False の場合、OSError を送出する。
+
+    Returns
+    -------
+    ImageFont.FreeTypeFont
+        読み込んだフォントオブジェクト。
+
+    Raises
+    ------
+    OSError
+        fallback=False かつフォントファイルが存在しない場合。
+    """
+    try:
+        return ImageFont.truetype(font_path, size, index=0)
+    except (OSError, IOError) as e:
+        if not fallback:
+            raise OSError(f"フォントの読み込みに失敗しました: {font_path}") from e
+        logger.warning(
+            "フォント '%s' が読み込めません。システムデフォルトフォントにフォールバックします。"
+            "日本語は描画できない場合があります。エラー: %s",
+            font_path,
+            e,
+        )
+        # Pillow 10.0 以降では load_default() が FreeTypeFont を返す
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return ImageFont.load_default()
+
+
+def draw_text_wrapped(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    position: tuple,
+    font: ImageFont.FreeTypeFont,
+    fill: tuple,
+    max_width: int,
+    line_spacing: int = 8,
+) -> None:
+    """テキストを指定幅で折り返して描画する。
+
+    Parameters
+    ----------
+    draw : ImageDraw.ImageDraw
+        描画対象の ImageDraw オブジェクト。
+    text : str
+        描画するテキスト。
+    position : tuple[int, int]
+        描画開始座標 (x, y)。左上基準。
+    font : ImageFont.FreeTypeFont
+        描画に使用するフォント。
+    fill : tuple[int, int, int]
+        テキスト色 (R, G, B)。
+    max_width : int
+        折り返しを行う最大幅（ピクセル）。
+    line_spacing : int
+        行間の追加ピクセル数（デフォルト: 8px）。
+    """
+    if not text:
+        return
+
+    x, y = position
+
+    # フォントの行高を取得
+    try:
+        # Pillow 10.0 以降は getbbox を使う
+        bbox = font.getbbox("A")
+        line_height = bbox[3] - bbox[1]
+    except AttributeError:
+        # 旧 Pillow のフォールバック
+        line_height = size if hasattr(font, "size") else 16  # type: ignore[attr-defined]
+
+    # 1文字ずつ処理してmax_widthを超えたら改行する
+    lines = []
+    current_line = ""
+
+    for char in text:
+        test_line = current_line + char
+        try:
+            line_width = font.getlength(test_line)
+        except AttributeError:
+            # Pillow < 9.2.0 のフォールバック
+            line_width = draw.textlength(test_line, font=font)  # type: ignore[attr-defined]
+
+        if line_width <= max_width:
+            current_line = test_line
+        else:
+            if current_line:
+                lines.append(current_line)
+            current_line = char
+
+    if current_line:
+        lines.append(current_line)
+
+    # 行ごとに描画
+    current_y = y
+    for line in lines:
+        draw.text((x, current_y), line, font=font, fill=fill)
+        current_y += line_height + line_spacing

--- a/src/thumbnail.py
+++ b/src/thumbnail.py
@@ -225,7 +225,7 @@ def draw_text_wrapped(
         line_height = bbox[3] - bbox[1]
     except AttributeError:
         # 旧 Pillow のフォールバック
-        line_height = size if hasattr(font, "size") else 16  # type: ignore[attr-defined]
+        line_height = font.size if hasattr(font, "size") else 16  # type: ignore[attr-defined]
 
     # 1文字ずつ処理してmax_widthを超えたら改行する
     lines = []

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -1,0 +1,261 @@
+"""サムネイル自動生成モジュール ユニットテスト
+
+テンプレート画像・フォントファイルが存在しない環境でも動作するよう、
+PIL.Image.new() で一時テンプレートを作成して使用する。
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+# src/ を import パスに追加
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from thumbnail import draw_text_wrapped, generate_thumbnail, load_font
+
+
+# ---------------------------------------------------------------------------
+# ヘルパー
+# ---------------------------------------------------------------------------
+
+
+def make_template(tmp_path: Path, size: tuple[int, int] = (1280, 720)) -> Path:
+    """テスト用テンプレート画像を tmp_path に作成して返す。"""
+    template_dir = tmp_path / "assets"
+    template_dir.mkdir()
+    template_path = template_dir / "thumbnail_template.png"
+    img = Image.new("RGB", size, color=(30, 30, 80))
+    img.save(template_path)
+    return template_path
+
+
+def make_config(tmp_path: Path, template_path: Path) -> dict:
+    """テスト用 config 辞書を返す。フォントは存在しないパスを指定する。"""
+    return {
+        "template_path": str(template_path),
+        "font_path": str(tmp_path / "nonexistent_font.ttc"),
+        "date": {"x": 80, "y": 40, "size": 48, "color": [255, 255, 255], "max_width": 600},
+        "title": {"x": 80, "y": 160, "size": 64, "color": [255, 255, 255], "max_width": 1100},
+        "scripture": {"x": 80, "y": 400, "size": 40, "color": [220, 220, 220], "max_width": 900},
+        "preacher": {"x": 80, "y": 480, "size": 40, "color": [220, 220, 220], "max_width": 600},
+    }
+
+
+# ---------------------------------------------------------------------------
+# 正常系テスト
+# ---------------------------------------------------------------------------
+
+
+def test_generate_thumbnail_creates_file(tmp_path: Path) -> None:
+    """正常生成: thumbnail.png が output_dir に生成される"""
+    template_path = make_template(tmp_path)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    config = make_config(tmp_path, template_path)
+
+    result = generate_thumbnail(
+        date="2026年4月19日",
+        title="忘れ得じ、彼のパリサイびと",
+        scripture="ヨハネの福音書 3章1〜15節",
+        preacher="前田 重雄 師",
+        output_dir=output_dir,
+        config=config,
+    )
+
+    assert result == output_dir / "thumbnail.png"
+    assert result.exists()
+
+
+def test_generate_thumbnail_output_size(tmp_path: Path) -> None:
+    """出力サイズ: 生成された PNG が 1280×720 px である"""
+    template_path = make_template(tmp_path)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    config = make_config(tmp_path, template_path)
+
+    result = generate_thumbnail(
+        date="2026年4月19日",
+        title="テストタイトル",
+        scripture="マタイ 1章1節",
+        preacher="テスト 説教者 師",
+        output_dir=output_dir,
+        config=config,
+    )
+
+    with Image.open(result) as img:
+        assert img.size == (1280, 720)
+
+
+def test_generate_thumbnail_overwrites_existing(tmp_path: Path) -> None:
+    """上書き動作: 既存の thumbnail.png が上書きされる"""
+    template_path = make_template(tmp_path)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    config = make_config(tmp_path, template_path)
+
+    # 先に既存ファイルを作成
+    existing = output_dir / "thumbnail.png"
+    existing.write_bytes(b"dummy content")
+    original_content = existing.read_bytes()
+
+    generate_thumbnail(
+        date="2026年4月19日",
+        title="上書きテスト",
+        scripture="聖書箇所",
+        preacher="説教者",
+        output_dir=output_dir,
+        config=config,
+    )
+
+    assert existing.exists()
+    # 内容が変わっていること（上書きされた）
+    assert existing.read_bytes() != original_content
+
+
+def test_generate_thumbnail_raises_when_template_missing(tmp_path: Path) -> None:
+    """テンプレート欠如: テンプレートが存在しないとき FileNotFoundError"""
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    config = {
+        "template_path": str(tmp_path / "nonexistent_template.png"),
+        "font_path": str(tmp_path / "nonexistent_font.ttc"),
+    }
+
+    with pytest.raises(FileNotFoundError):
+        generate_thumbnail(
+            date="2026年4月19日",
+            title="テスト",
+            scripture="聖書箇所",
+            preacher="説教者",
+            output_dir=output_dir,
+            config=config,
+        )
+
+
+def test_generate_thumbnail_raises_when_output_dir_missing(tmp_path: Path) -> None:
+    """output_dir 欠如: output_dir が存在しないとき FileNotFoundError"""
+    template_path = make_template(tmp_path)
+    config = make_config(tmp_path, template_path)
+    nonexistent_dir = tmp_path / "nonexistent_output"
+
+    with pytest.raises(FileNotFoundError):
+        generate_thumbnail(
+            date="2026年4月19日",
+            title="テスト",
+            scripture="聖書箇所",
+            preacher="説教者",
+            output_dir=nonexistent_dir,
+            config=config,
+        )
+
+
+def test_generate_thumbnail_font_fallback(tmp_path: Path) -> None:
+    """フォントフォールバック: meiryob.ttc が存在しないとき例外にならず処理続行"""
+    template_path = make_template(tmp_path)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    # 存在しないフォントパスを指定
+    config = make_config(tmp_path, template_path)
+
+    # 例外が発生しないこと・ファイルが生成されること
+    result = generate_thumbnail(
+        date="2026年4月19日",
+        title="フォントフォールバックテスト",
+        scripture="マタイ 1章1節",
+        preacher="テスト 師",
+        output_dir=output_dir,
+        config=config,
+    )
+
+    assert result.exists()
+
+
+def test_generate_thumbnail_empty_fields(tmp_path: Path) -> None:
+    """空文字列の入力: 全フィールドが空文字列でも例外が発生しない"""
+    template_path = make_template(tmp_path)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    config = make_config(tmp_path, template_path)
+
+    # 例外が発生しないこと
+    result = generate_thumbnail(
+        date="",
+        title="",
+        scripture="",
+        preacher="",
+        output_dir=output_dir,
+        config=config,
+    )
+
+    assert result.exists()
+
+
+def test_generate_thumbnail_config_none(tmp_path: Path) -> None:
+    """config なし: config=None でデフォルト値で動作する"""
+    # デフォルトのテンプレートパスは assets/thumbnail_template.png だが、
+    # テスト環境では存在しないので FileNotFoundError が発生するはず。
+    # それ以外の例外（AttributeError 等）が発生しないことを確認する。
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    with pytest.raises(FileNotFoundError):
+        generate_thumbnail(
+            date="2026年4月19日",
+            title="テスト",
+            scripture="聖書箇所",
+            preacher="説教者",
+            output_dir=output_dir,
+            config=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# draw_text_wrapped のテスト
+# ---------------------------------------------------------------------------
+
+
+def test_draw_text_wrapped_wraps_long_text(tmp_path: Path) -> None:
+    """長文タイトルの折り返し: max_width を超えるテキストが複数行に折り返される"""
+    from PIL import ImageDraw, ImageFont
+
+    img = Image.new("RGB", (400, 400), color=(0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    font = ImageFont.load_default()
+
+    # max_width を非常に小さくして確実に折り返しが起きるようにする
+    long_text = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+    # 例外が発生しないことと、描画が行われること（y座標が進むこと）を確認する。
+    # 副作用として img に描画されるが、直接折り返しを検証するには
+    # draw_text_wrapped が行数を返さないため、例外なし完了を確認する。
+    draw_text_wrapped(
+        draw=draw,
+        text=long_text,
+        position=(0, 0),
+        font=font,
+        fill=(255, 255, 255),
+        max_width=50,
+        line_spacing=8,
+    )
+    # 例外なしで完了すれば OK
+
+
+# ---------------------------------------------------------------------------
+# load_font のテスト
+# ---------------------------------------------------------------------------
+
+
+def test_load_font_fallback_when_missing(tmp_path: Path) -> None:
+    """フォントフォールバック: フォントが存在しないとき fallback=True で例外にならない"""
+    from PIL import ImageFont
+
+    font = load_font(str(tmp_path / "nonexistent.ttc"), size=48, fallback=True)
+    assert font is not None
+
+
+def test_load_font_raises_when_missing_no_fallback(tmp_path: Path) -> None:
+    """フォントが存在しないとき fallback=False で OSError"""
+    with pytest.raises(OSError):
+        load_font(str(tmp_path / "nonexistent.ttc"), size=48, fallback=False)

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -259,3 +259,18 @@ def test_load_font_raises_when_missing_no_fallback(tmp_path: Path) -> None:
     """フォントが存在しないとき fallback=False で OSError"""
     with pytest.raises(OSError):
         load_font(str(tmp_path / "nonexistent.ttc"), size=48, fallback=False)
+
+
+def test_draw_text_wrapped_fallback_line_height(tmp_path: Path) -> None:
+    """getbbox が AttributeError を送出するフォールバック経路で NameError が発生しないこと"""
+    from unittest.mock import MagicMock, patch
+    from src.thumbnail import draw_text_wrapped
+    from PIL import Image, ImageDraw, ImageFont
+
+    img = Image.new("RGB", (400, 200), color=(0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    font = ImageFont.load_default()
+
+    with patch.object(type(font), "getbbox", side_effect=AttributeError):
+        # NameError が発生しないこと
+        draw_text_wrapped(draw, "テスト テキスト", (0, 0), font, (255, 255, 255), 200)


### PR DESCRIPTION
## Summary

- `src/thumbnail.py`: サムネイル自動生成モジュール実装
  - `generate_thumbnail()`: 礼拝情報からPNG生成（1280×720）
  - `load_font()`: Meiryo Bold読み込み・フォールバック対応
  - `draw_text_wrapped()`: 日本語テキスト折り返し描画
- `tests/test_thumbnail.py`: 単体テスト12件（テンプレート・フォント不要で動作）

## TDDサイクル

| コミット | ステージ | 内容 |
|---------|---------|------|
| `2075be4` | RED | テスト11件追加（全FAIL確認） |
| `4833f90` | GREEN | 実装（全PASS確認） |
| `2c6fdc9` | RED | W-1バグ再現テスト追加 |
| `cb08505` | GREEN | バグ修正（全PASS確認） |

## Test plan

- [x] 単体テスト 12件 全PASS（`pytest tests/test_thumbnail.py`）
- [x] QAちゃんレビュー PASS（W-1修正済み）
- [ ] 実機手動確認: `assets/thumbnail_template.png` を配置して日本語描画・見た目を目視確認

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)